### PR TITLE
Fix two bugs: macOS MMseqs2 version and integer contig names

### DIFF
--- a/src/dnaapler/utils/all.py
+++ b/src/dnaapler/utils/all.py
@@ -62,7 +62,8 @@ def all_process_MMseqs2_output_and_reorient(
     # read in the dataframe from MMseqs2
     try:
         MMseqs2_df = pd.read_csv(
-            MMseqs2_file, delimiter="\t", index_col=False, names=col_list
+            MMseqs2_file, delimiter="\t", index_col=False, names=col_list,
+            dtype={"qseqid": "object"}
         )
 
     except Exception:

--- a/src/dnaapler/utils/bulk.py
+++ b/src/dnaapler/utils/bulk.py
@@ -153,7 +153,8 @@ def bulk_process_MMseqs2_output_and_reorient(
     # read in the dataframe from MMseqs2
     try:
         MMseqs2_df = pd.read_csv(
-            MMseqs2_file, delimiter="\t", index_col=False, names=col_list
+            MMseqs2_file, delimiter="\t", index_col=False, names=col_list,
+            dtype={"qseqid": "object"}
         )
 
     except Exception:

--- a/src/dnaapler/utils/processing.py
+++ b/src/dnaapler/utils/processing.py
@@ -50,7 +50,8 @@ def process_MMseqs2_output_and_reorient(
     # read in the dataframe from MMseqs2
     try:
         MMseqs2_df = pd.read_csv(
-            MMseqs2_file, delimiter="\t", index_col=False, names=col_list
+            MMseqs2_file, delimiter="\t", index_col=False, names=col_list,
+            dtype={"qseqid": "object"}
         )
     except Exception:
         logger.error("There was an issue with parsing the MMseqs2 output file.")

--- a/src/dnaapler/utils/util.py
+++ b/src/dnaapler/utils/util.py
@@ -129,17 +129,23 @@ def check_mmseqs2_version():
         else:
             raise ValueError("MMseqs2 version not found")
 
-        mmseqs_major_version = int(mmseqs_version.split(".")[0])
-        mmseqs_minor_version = mmseqs_version.split(".")[1]
+        # The pre-built binary on GitHub reports its version using the commit hash instead of
+        # a version number.
+        if mmseqs_version.startswith('45111b6'):
+            logger.info(f"MMseqs2 version found is {mmseqs_version}")
 
-        logger.info(
-            f"MMseqs2 version found is v{mmseqs_major_version}.{mmseqs_minor_version}"
-        )
+        else:
+            mmseqs_major_version = int(mmseqs_version.split(".")[0])
+            mmseqs_minor_version = mmseqs_version.split(".")[1]
 
-        if mmseqs_major_version != 13:
-            logger.error("MMseqs2 is the wrong version. Please install v13.45111")
-        if mmseqs_minor_version != "45111":
-            logger.error("MMseqs2 is the wrong version. Please install v13.45111")
+            logger.info(
+                f"MMseqs2 version found is v{mmseqs_major_version}.{mmseqs_minor_version}"
+            )
+
+            if mmseqs_major_version != 13:
+                logger.error("MMseqs2 is the wrong version. Please install v13.45111")
+            if mmseqs_minor_version != "45111":
+                logger.error("MMseqs2 is the wrong version. Please install v13.45111")
 
         logger.info("MMseqs2 version is ok.")
 


### PR DESCRIPTION
## macOS MMseqs2 version

Currently, Dnaapler checks for an MMseqs2 version string in the format `major.minor`. However, the macOS MMseqs2 v13.45111 binary (downloaded from [MMseqs2 release page](https://github.com/soedinglab/MMseqs2/releases/tag/13-45111)) reports its version as a hash (`45111b641859ed0ddd875b94d6fd1aef1a675b7e`). This causes Dnaapler's version check to fail.

Fix: Updated the version-check logic to support hash-based version numbers.


## Integer contig names

When running Dnaapler on an Autocycler assembly with integer-named sequences, the following issue arose:
```python
filtered_df = MMseqs2_df[MMseqs2_df["qseqid"] == short_contig]
```
In this case, `short_contig` was a string, but the `qseqid` column in the MMseqs2 results dataframe was inferred as an integer type. This type mismatch caused the filtered dataframe to always be empty.

Fix: Enforced the `qseqid` column to always load as a string (object type) when reading MMseqs2 results with Pandas.