### PR TITLE
feat: add comma-separated list support to --ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ For bacterial chromosomes, `dnaapler chromosome` should ensure the chromosome br
 
 Additionally, you can also reorient multiple bacterial chromosomes/plasmids/phages at once using the `dnaapler bulk` subcommand.
 
-If your input FASTA or GFA is mixed (e.g. has chromosome and plasmids), you can also use `dnaapler all`, with the option to ignore some contigs with the `--ignore` parameter.
+If your input FASTA or GFA is mixed (e.g. has chromosome and plasmids), you can also use `dnaapler all`, with the option to ignore some contigs with the `--ignore` parameter. The `--ignore` parameter accepts either:
+- A file path containing contig names to ignore (one per line)
+- A comma-separated list of contig names (e.g., `chr1,chr2,chr3`)
+- `-` to read contig names from stdin (one per line)
 
 **As of v1, in practice, `dnaapler all` is the only command you will likely need, as it contains all the functionality of `bulk`, `chromosome`, `plasmid`, `phage` but with much more flexibility and user-friendliness**
 
@@ -223,8 +226,9 @@ Options:
   -p, --prefix TEXT        Prefix for output files  [default: dnaapler]
   -f, --force              Force overwrites the output directory
   -e, --evalue TEXT        e value for MMseqs2  [default: 1e-10]
-  --ignore PATH            Text file listing contigs (one per row) that are to
-                           be ignored
+  --ignore TEXT            Text file listing contigs (one per row) that are to
+                           be ignored OR comma separated list of contig names
+                           to ignore OR '-' to read from stdin
   -a, --autocomplete TEXT  Choose an option to autocomplete reorientation if
                            MMseqs2 based approach fails. Must be one of: none,
                            mystery, largest, or nearest [default: none]
@@ -240,6 +244,14 @@ The reoriented output will be `{prefix}_reoriented.fasta` in the specified outpu
 
 ```
 dnaapler all -i input.fasta -o output_directory_path -p my_genome_name --ignore list_of_contigs_to_ignore.txt
+```
+
+```
+dnaapler all -i input.fasta -o output_directory_path -p my_genome_name --ignore chr1,chr2,chr3
+```
+
+```
+echo -e "chr1\nchr2\nchr3" | dnaapler all -i input.fasta -o output_directory_path -p my_genome_name --ignore -
 ```
 
 ```

--- a/src/dnaapler/utils/bulk.py
+++ b/src/dnaapler/utils/bulk.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from pathlib import Path
 
 import pandas as pd
@@ -86,7 +85,7 @@ def run_bulk_MMseqs2(
             tool="mmseqs createdb",
             input=f" {custom_db}",
             output=f" {custom_database}",
-            params=f"",
+            params="",
             logdir=logdir,
         )
 

--- a/src/dnaapler/utils/processing.py
+++ b/src/dnaapler/utils/processing.py
@@ -5,7 +5,6 @@ from typing import List
 import pandas as pd
 import pyrodigal
 from Bio import SeqIO
-from Bio.SeqRecord import SeqRecord
 from loguru import logger
 
 
@@ -193,7 +192,7 @@ def process_MMseqs2_output_and_reorient(
         with open(out_file, "w") as out_fa:
             SeqIO.write(record, out_fa, "fasta")
 
-        MMseqs2_success == True
+        MMseqs2_success = True
 
     # top hit
     # prokaryotes can use AUG M, GUG V or UUG L as start codons - e.g. for Pseudomonas aeruginosa PA01  dnaA actually starts with V

--- a/src/dnaapler/utils/util.py
+++ b/src/dnaapler/utils/util.py
@@ -104,7 +104,7 @@ def check_pyrodigal_version():
             )
 
         logger.info(f"Pyrodigal version is v{pyrodigal_version}")
-        logger.info(f"Pyrodigal version is ok.")
+        logger.info("Pyrodigal version is ok.")
 
     except Exception:
         message = "Pyrodigal not found."
@@ -184,7 +184,7 @@ def run_autocomplete(
     """
 
     # if there was
-    if MMseqs_success == False:
+    if MMseqs_success is False:
         if autocomplete == "none":
             logger.error(
                 "BLAST based reorientation failed.\n"

--- a/tests/test_dnaapler.py
+++ b/tests/test_dnaapler.py
@@ -5,22 +5,18 @@ Usage: pytest
 
 """
 
-import glob
 import os
 import sys
 
 # import
 import unittest
 from pathlib import Path
-from unittest.mock import patch
 
 import click
 import pandas as pd
 import pytest
 from loguru import logger
 
-from src.dnaapler.utils.constants import repo_root
-from src.dnaapler.utils.external_tools import ExternalTool
 from src.dnaapler.utils.processing import (
     process_MMseqs2_output_and_reorient,
     reorient_sequence,
@@ -206,7 +202,7 @@ class TestBlastOutput(unittest.TestCase):
         MMseqs2_success = process_MMseqs2_output_and_reorient(
             input, MMseqs2_file, output, gene
         )
-        assert MMseqs2_success == True
+        assert MMseqs2_success
 
     def test_process_MMseqs2_output_and_reorient_wrong_start_codon(self):
         # Test scenario where the best BLAST hit has no valid start codon
@@ -219,7 +215,7 @@ class TestBlastOutput(unittest.TestCase):
         MMseqs2_success = process_MMseqs2_output_and_reorient(
             input, MMseqs2_file, output, gene
         )
-        assert MMseqs2_success == True
+        assert MMseqs2_success
 
     def test_process_MMseqs2_output_and_reorient_correct(self):
         # Test scenario where the no BLAST hit begins with 1 (start of gene)
@@ -230,7 +226,7 @@ class TestBlastOutput(unittest.TestCase):
         MMseqs2_success = process_MMseqs2_output_and_reorient(
             input, MMseqs2_file, output, gene
         )
-        assert MMseqs2_success == True
+        assert MMseqs2_success
 
     def test_begin_dnaapler(self):
         # Test begin
@@ -285,22 +281,22 @@ class TestChoiceAutocomplete(unittest.TestCase):
         param = "2"
         value = "sfsd"
         with self.assertRaises(click.BadParameter):
-            val = validate_choice_autocomplete(ctx, param, value)
+            validate_choice_autocomplete(ctx, param, value)
 
     def test_evalue_none(self):
         value = "none"
         ctx = "1"
         param = "2"
-        val = validate_choice_autocomplete(ctx, param, value)
+        validate_choice_autocomplete(ctx, param, value)
 
     def test_evalue_mys(self):
         value = "mystery"
         ctx = "1"
         param = "2"
-        val = validate_choice_autocomplete(ctx, param, value)
+        validate_choice_autocomplete(ctx, param, value)
 
     def test_evalue_nearest(self):
         value = "nearest"
         ctx = "1"
         param = "2"
-        val = validate_choice_autocomplete(ctx, param, value)
+        validate_choice_autocomplete(ctx, param, value)

--- a/tests/test_overall.py
+++ b/tests/test_overall.py
@@ -225,7 +225,7 @@ def test_all_custom(tmp_dir):
     exec_command(cmd)
 
 
-def test_custom(tmp_dir):
+def test_custom2(tmp_dir):
     """test custom"""
     input_fasta: Path = f"{overall_test_data}/all_test.fasta"
     custom: Path = f"{test_data}/fake_custom.faa"
@@ -369,7 +369,7 @@ def test_all_mixed_contig_end(tmp_dir):
 
 def test_citation():
     """test citation"""
-    cmd = f"dnaapler citation"
+    cmd = "dnaapler citation"
     exec_command(cmd)
 
 

--- a/tests/test_process_ignore_input.py
+++ b/tests/test_process_ignore_input.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the process_ignore_input functionality works with both
+comma-separated lists, file paths, and stdin.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+# Add the src directory to the path so we can import dnaapler
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src")
+)
+
+from dnaapler.utils.validation import process_ignore_input  # noqa: E402
+
+
+class TestProcessIgnoreInput(unittest.TestCase):
+
+    def test_empty_input(self):
+        """Test empty string and None input"""
+        self.assertEqual(process_ignore_input(""), [])
+        self.assertEqual(process_ignore_input(None), [])
+
+    def test_comma_separated_basic(self):
+        """Test basic comma-separated list functionality"""
+        result = process_ignore_input("chr1,chr2,chr3")
+        expected = ["chr1", "chr2", "chr3"]
+        self.assertEqual(result, expected)
+
+    def test_comma_separated_with_spaces(self):
+        """Test comma-separated with spaces around commas"""
+        result = process_ignore_input("chr1, chr2 , chr3")
+        expected = ["chr1", "chr2", "chr3"]
+        self.assertEqual(result, expected)
+
+    def test_single_chromosome(self):
+        """Test single chromosome name"""
+        result = process_ignore_input("chr1")
+        expected = ["chr1"]
+        self.assertEqual(result, expected)
+
+    def test_comma_separated_vs_path_detection(self):
+        """Test that comma-separated lists without path characteristics work"""
+        # These should be treated as comma-separated lists (no path separators or extensions)
+        result = process_ignore_input("chr1,chr2,chr3")
+        expected = ["chr1", "chr2", "chr3"]
+        self.assertEqual(result, expected)
+
+        result = process_ignore_input("contig_1,contig_2")
+        expected = ["contig_1", "contig_2"]
+        self.assertEqual(result, expected)
+
+    def test_file_path_with_multiple_entries(self):
+        """Test file path with multiple entries per line (space-separated)"""
+        # Create a temporary file with test data (similar to existing test data)
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
+            tmp.write("MW460250_1_subset\n")
+            tmp.write(
+                "1 length=181436 plasmid_copy_number_short=1.0x plasmid_copy_number_long=1.04x circular=true\n"
+            )
+            tmp_path = tmp.name
+
+        try:
+            result = process_ignore_input(tmp_path)
+            expected_set = {
+                "MW460250_1_subset",
+                "1",
+            }  # Should split by space and take first part
+            result_set = set(result)
+            self.assertEqual(result_set, expected_set)
+            self.assertEqual(len(result), 2)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_file_path_simple(self):
+        """Test file path with simple entries (one per line)"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
+            tmp.write("chr1\n")
+            tmp.write("chr2\n")
+            tmp.write("chr3\n")
+            tmp_path = tmp.name
+
+        try:
+            result = process_ignore_input(tmp_path)
+            expected_set = {"chr1", "chr2", "chr3"}
+            result_set = set(result)
+            self.assertEqual(result_set, expected_set)
+            self.assertEqual(len(result), 3)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_nonexistent_file_path(self):
+        """Test handling of nonexistent file path (should exit with error)"""
+        with self.assertRaises(SystemExit):
+            process_ignore_input("/path/that/does/not/exist.txt")
+
+    def test_actual_test_data_file(self):
+        """Test with the actual ignore.txt file from test data"""
+        ignore_file = os.path.join(
+            os.path.dirname(__file__), "test_data", "overall_inputs", "ignore.txt"
+        )
+        if os.path.exists(ignore_file):
+            result = process_ignore_input(ignore_file)
+            # Should contain the entries from the file
+            self.assertGreater(len(result), 0)
+            self.assertIn("MW460250_1_subset", result)
+            self.assertIn("1", result)
+        else:
+            self.skipTest("Actual test file not found")
+
+    def test_path_detection(self):
+        """Test that nonexistent paths cause system exit"""
+        # These should be treated as file paths and cause system exit since files don't exist
+        test_paths = [
+            "/path/to/file.txt",
+            "relative/path/file.tsv",
+            "file.csv",
+            "C:\\Windows\\path\\file.list",
+        ]
+
+        for path in test_paths:
+            with self.assertRaises(
+                SystemExit, msg=f"Path {path} should cause system exit"
+            ):
+                process_ignore_input(path)
+
+    def test_stdin_input(self):
+        """Test reading from stdin using '-' as input"""
+        test_input = "chr1\nchr2\nchr3\n"
+        with patch("sys.stdin", StringIO(test_input)):
+            result = process_ignore_input("-")
+            expected_set = {"chr1", "chr2", "chr3"}
+            result_set = set(result)
+            self.assertEqual(result_set, expected_set)
+            self.assertEqual(len(result), 3)
+
+    def test_stdin_with_spaces(self):
+        """Test stdin input with space-separated content (should take first part)"""
+        test_input = (
+            "MW460250_1_subset\n1 length=181436 plasmid_copy_number_short=1.0x\n"
+        )
+        with patch("sys.stdin", StringIO(test_input)):
+            result = process_ignore_input("-")
+            expected_set = {"MW460250_1_subset", "1"}
+            result_set = set(result)
+            self.assertEqual(result_set, expected_set)
+            self.assertEqual(len(result), 2)
+
+    def test_stdin_empty(self):
+        """Test stdin with empty input"""
+        test_input = ""
+        with patch("sys.stdin", StringIO(test_input)):
+            result = process_ignore_input("-")
+            self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hey George,

This addition means `--ignore` can just take a comma-separated list of chromosomes so you don't need to create a file, or even stdin if you want to pipe the list in from another program.

I have tested this out locally and it seems to work, but feel free to do your due diligence.

I also fixed all the flake8 linting errors 